### PR TITLE
article投稿機能にエラーメッセージの設定

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -10,8 +10,13 @@ class ArticlesController < ApplicationController
   end
 
   def create
-    article = current_user.articles.create!(article_params)
-    redirect_to articles_path, notice: '投稿しました'
+    @article = current_user.articles.new(article_params)
+    if @article.save
+      redirect_to articles_path, notice: '投稿しました'
+    else
+      flash.now[:alert] = '投稿に失敗しました'
+      render :new
+    end
   end
 
   def show
@@ -21,8 +26,12 @@ class ArticlesController < ApplicationController
   end
 
   def update
-    @article.update!(article_params)
-    redirect_to articles_path, notice: '更新しました'
+    if @article.update(article_params)
+      redirect_to articles_path, notice: '更新しました'
+    else
+      flash.now[:alert] = "更新に失敗しました"
+      render :edit
+    end
   end
 
   def destroy

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,5 +1,6 @@
 class Article < ApplicationRecord
   belongs_to :user
   belongs_to :exercise
-  validates :day, :minutes, :body, presence: true
+  validates :day, :body, presence: true
+  validates :minutes, presence: true, numericality: { only_integer: true }
 end

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,16 +1,16 @@
 <%= form_with model: @article, local: true do |form| %>
   <div>
-    <%= form.label :day, "日付" %>
+    <%= form.label :day %>
     <%= form.date_field :day %>
   </div>
   <div>
-    <%= form.label :exercise_id, "エクササイズ" %>
+    <%= form.label :exercise_id %>
     <%= form.collection_select :exercise_id, Exercise.all, :id, :name %>
-    <%= form.label :minutes, "時間（分）" %>
-    <%= form.number_field :minutes %>
+    <%= form.number_field :minutes, min: "0" %>
+    <%= form.label :minutes %>
   </div>
   <div>
-    <%= form.label :body, "感想" %>
+    <%= form.label :body %>
     <%= form.text_area :body %>
   </div>
   <div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,9 +3,15 @@ ja:
   activerecord:
     models:
       exercise: エクササイズ
+      article: 投稿
     attributes:
       exercise:
         name: エクササイズ名
+      article:
+        day: 日付
+        exercise_id: エクササイズ
+        minutes: 分
+        body: 感想
     errors:
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'


### PR DESCRIPTION
close #48 
## 実装内容
- Articleモデルにバリデーションを追加
-  エラーメッセージを日本語化・時間は整数のみ許可へ
- バリデーションエラー時に投稿ページをレンダリングするように修正