### PR TITLE
Likeモデルとテーブルの作成 

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,6 +1,7 @@
 class Article < ApplicationRecord
   belongs_to :user
   belongs_to :exercise
+  has_many :likes, dependent: :destroy
   validates :day, :body, presence: true
   validates :minutes, presence: true, numericality: { only_integer: true }
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,4 @@
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :article
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,4 +1,8 @@
 class Like < ApplicationRecord
   belongs_to :user
   belongs_to :article
+  validates :user_id, uniqueness: {
+    scope: :article_id,
+    message: 'は同じ投稿に2回以上いいねはできません'
+  }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_many :articles, dependent: :destroy
   has_many :exercises, dependent: :destroy
+  has_many :likes, dependent: :destroy
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
     models:
       exercise: エクササイズ
       article: 投稿
+      like: いいね
     attributes:
       exercise:
         name: エクササイズ名
@@ -12,6 +13,9 @@ ja:
         exercise_id: エクササイズ
         minutes: 分
         body: 感想
+      like:
+        user: ユーザー
+        article: 投稿
     errors:
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'

--- a/db/migrate/20210528101131_create_likes.rb
+++ b/db/migrate/20210528101131_create_likes.rb
@@ -1,0 +1,11 @@
+class CreateLikes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :likes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :article, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :likes, %i[user_id article_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_26_120154) do
+ActiveRecord::Schema.define(version: 2021_05_28_101131) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,16 @@ ActiveRecord::Schema.define(version: 2021_05_26_120154) do
     t.index ["user_id"], name: "index_exercises_on_user_id"
   end
 
+  create_table "likes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "article_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_likes_on_article_id"
+    t.index ["user_id", "article_id"], name: "index_likes_on_user_id_and_article_id", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -54,4 +64,6 @@ ActiveRecord::Schema.define(version: 2021_05_26_120154) do
   add_foreign_key "articles", "exercises"
   add_foreign_key "articles", "users"
   add_foreign_key "exercises", "users"
+  add_foreign_key "likes", "articles"
+  add_foreign_key "likes", "users"
 end

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :like do
+    user { nil }
+    article { nil }
+  end
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Like, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
close #49 
## 実装内容
-  Likeモデルとlikesテーブル作成
- userとarticleモデルの関連づけ
- [user_id, article_id] の組が一意となるようにバリデーションを設定
- Likeモデルに関する日本語訳の追加