### PR TITLE
記事投稿ページ・一覧ページのスタイル調整

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -138,3 +138,13 @@ h1 {
   border-radius: 60%;
   margin-right: 10px;
 }
+.drop-hover:hover>.dropdown-menu {
+  display: block !important;
+  top: calc(30.1px);
+}
+.dropdown-menu {
+  padding: 15px;
+}
+.card-text.col-xs-3 {
+  color: rgba(0, 0, 0, 0.6);
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -113,11 +113,12 @@ h1 {
 // エクササイズ登録画面
 .card {
   margin: 120px 20px;
+  padding: 20px;
   border-radius: 16px;
   box-shadow: 2px 2px 4px #ccc;
 }
 .card-title {
-  margin: 60px;
+  margin: 40px;
 }
 // 登録エクササイズ一覧
 .card-list {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -51,6 +51,10 @@ header {
   background: #FAB95B;
   border-color: #FAB95B;
 }
+.pagination {
+  justify-content: center;
+  padding: 30px;
+}
 // ホバー
 .pagination>li>a:hover {
   border-radius: 15px;
@@ -112,7 +116,8 @@ h1 {
 }
 // エクササイズ登録画面
 .card {
-  padding: 30px;
+  padding: 20px;
+  margin-top: 20px;
   border-radius: 10px;
   box-shadow: 2px 2px 4px #ccc;
 }
@@ -150,5 +155,5 @@ h1 {
   color: rgba(0, 0, 0, 0.6);
 }
 .row.justify-content-start {
-margin: 15px;
+  margin: 15px;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -138,6 +138,7 @@ h1 {
   border-radius: 60%;
   margin-right: 10px;
 }
+// 投稿一覧
 .drop-hover:hover>.dropdown-menu {
   display: block !important;
   top: calc(30.1px);
@@ -145,6 +146,9 @@ h1 {
 .dropdown-menu {
   padding: 15px;
 }
-.card-text.col-xs-3 {
+.card-text-day {
   color: rgba(0, 0, 0, 0.6);
+}
+.row.justify-content-start {
+margin: 15px;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -112,9 +112,8 @@ h1 {
 }
 // エクササイズ登録画面
 .card {
-  margin: 120px 20px;
-  padding: 20px;
-  border-radius: 16px;
+  padding: 30px;
+  border-radius: 10px;
   box-shadow: 2px 2px 4px #ccc;
 }
 .card-title {
@@ -123,7 +122,7 @@ h1 {
 // 登録エクササイズ一覧
 .card-list {
   margin: 40px 5px;
-  border-radius: 16px;
+  border-radius: 10px;
   box-shadow: 2px 2px 4px #ccc;
 }
 .card-body>p {

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -4,8 +4,7 @@ class ArticlesController < ApplicationController
   PER_PAGE = 5
 
   def index
-    @articles = Article.includes(:user, :likes).order(created_at: :desc)
-    @articles = Article.page(params[:page]).per(PER_PAGE)
+    @articles = Article.includes(:user, :likes).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
   end
 
   def new

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -8,8 +8,8 @@
 					<% else %>
 						<%= image_tag ("default.png"), size: "70x60" %>
 					<% end %>
-					<h5 class="card-name"><%= article.user.name %></h5>
-					<p class="card-text-day"><%= article.day %></p>
+						<h5 class="card-name"><%= article.user.name %></h5>
+						<p class="card-text-day"><%= article.day %></p>
 					<div class="dropdown drop-hover">
 						<i class="material-icons">more_vert</i>
 						<ul class="dropdown-menu">

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -1,32 +1,26 @@
 <div class="container">
-<div class="row">
 <div class="col-12">
 <div class="card" style="height: 20rem;">
 <div class="card-body">
 <div class="row">
 <% if article.user.profile_image? %>
-<%= image_tag article.user.profile_image.url, size: "90x80", class: "image_icons" %>
+<%= image_tag article.user.profile_image.url, size: "70x60", class: "image_icons" %>
 <% else %>
-<%= image_tag ("default.png"), size: "90x80" %>
+<%= image_tag ("default.png"), size: "70x60" %>
 <% end %>
-<h5 class="card-name"><%= article.user.name %></h5>
-<p class="card-text"><%= article.day %></p>
-</div>
-<div class="row">
-<p class="card-text">エクササイズ <%= article.exercise.name %></p>
-<p><%= article.minutes %>分</p>
-</div>
-<div class="row">
-<p class="card-text"><%= article.body %></p>
-</div>
-<div class="row">
-<p id="article-<%= article.id %>">
-<% if article.liked_by?(current_user) %>
-<%= render "like", post: article %>
-<% else %>
-<%= render "dislike", post: article %>
+<h5 class="card-name col"><%= article.user.name %></h5>
+<p class="card-text col-xs-3"><%= article.day %></p>
+<div class="dropdown drop-hover col-xs-1">
+<i class="material-icons">more_vert</i>
+<ul class="dropdown-menu">
+<li class="dropright drop-hover">
+<a class="dropdown-item"><%= link_to "詳細", article %></a>
+<% if current_user.id == article.user_id %>
+<a class="dropdown-item"><%= link_to "編集", edit_article_path(article) %></a>
+<a class="dropdown-item"><%= link_to "削除", article_path(article), method: :delete, data: { confirm: "削除しますか？" } %></a>
 <% end %>
-</p>
+</li>
+</ul>
 </div>
 </div>
 </div>

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -2,15 +2,15 @@
 <div class="col-12">
 <div class="card" style="height: 20rem;">
 <div class="card-body">
-<div class="row">
+<div class="row justify-content-between">
 <% if article.user.profile_image? %>
 <%= image_tag article.user.profile_image.url, size: "70x60", class: "image_icons" %>
 <% else %>
 <%= image_tag ("default.png"), size: "70x60" %>
 <% end %>
-<h5 class="card-name col"><%= article.user.name %></h5>
-<p class="card-text col-xs-3"><%= article.day %></p>
-<div class="dropdown drop-hover col-xs-1">
+<h5 class="card-name"><%= article.user.name %></h5>
+<p class="card-text-day"><%= article.day %></p>
+<div class="dropdown drop-hover">
 <i class="material-icons">more_vert</i>
 <ul class="dropdown-menu">
 <li class="dropright drop-hover">
@@ -23,6 +23,14 @@
 </ul>
 </div>
 </div>
+<div class="row justify-content-start">
+<p>エクササイズ：<%= article.exercise.name %></p>
+<p><%= article.minutes %>分</p>
+</div>
+<div class="row justify-content-start">
+<p><%= article.body %></p>
+</div>
+<hr>
 </div>
 </div>
 </div>

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -1,25 +1,35 @@
-<table>
-  <tbody>
-    <p>
-      <p><%= article.day %></p>
-      <p>名前 <%= article.user.name %></p>
-      <p>エクササイズ <%= article.exercise.name %></p>
-      <p><%= article.minutes %>分</p>
-      <p>感想 <%= article.body %></p>
-    </p>
-    <p id="article-<%= article.id %>">
-      <% if article.liked_by?(current_user) %>
-        <%= render "like", post: article %>
-      <% else %>
-        <%= render "dislike", post: article %>
-      <% end %>
-    </p>
-    <p>
-      <%= link_to "詳細", article %>
-      <% if current_user.id == article.user_id %>
-        <%= link_to "編集", edit_article_path(article) %>
-        <%= link_to "削除", article_path(article), method: :delete, data: { confirm: "削除しますか？" } %>
-      <% end %>
-    </p>
-  </tbody>
-</table>
+<div class="container">
+<div class="row">
+<div class="col-12">
+<div class="card" style="height: 20rem;">
+<div class="card-body">
+<div class="row">
+<% if article.user.profile_image? %>
+<%= image_tag article.user.profile_image.url, size: "90x80", class: "image_icons" %>
+<% else %>
+<%= image_tag ("default.png"), size: "90x80" %>
+<% end %>
+<h5 class="card-name"><%= article.user.name %></h5>
+<p class="card-text"><%= article.day %></p>
+</div>
+<div class="row">
+<p class="card-text">エクササイズ <%= article.exercise.name %></p>
+<p><%= article.minutes %>分</p>
+</div>
+<div class="row">
+<p class="card-text"><%= article.body %></p>
+</div>
+<div class="row">
+<p id="article-<%= article.id %>">
+<% if article.liked_by?(current_user) %>
+<%= render "like", post: article %>
+<% else %>
+<%= render "dislike", post: article %>
+<% end %>
+</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -1,37 +1,45 @@
 <div class="container">
-<div class="col-12">
-<div class="card" style="height: 20rem;">
-<div class="card-body">
-<div class="row justify-content-between">
-<% if article.user.profile_image? %>
-<%= image_tag article.user.profile_image.url, size: "70x60", class: "image_icons" %>
-<% else %>
-<%= image_tag ("default.png"), size: "70x60" %>
-<% end %>
-<h5 class="card-name"><%= article.user.name %></h5>
-<p class="card-text-day"><%= article.day %></p>
-<div class="dropdown drop-hover">
-<i class="material-icons">more_vert</i>
-<ul class="dropdown-menu">
-<li class="dropright drop-hover">
-<a class="dropdown-item"><%= link_to "詳細", article %></a>
-<% if current_user.id == article.user_id %>
-<a class="dropdown-item"><%= link_to "編集", edit_article_path(article) %></a>
-<a class="dropdown-item"><%= link_to "削除", article_path(article), method: :delete, data: { confirm: "削除しますか？" } %></a>
-<% end %>
-</li>
-</ul>
-</div>
-</div>
-<div class="row justify-content-start">
-<p>エクササイズ：<%= article.exercise.name %></p>
-<p><%= article.minutes %>分</p>
-</div>
-<div class="row justify-content-start">
-<p><%= article.body %></p>
-</div>
-<hr>
-</div>
-</div>
-</div>
+	<div class="col-12">
+		<div class="card" style="height: 20rem;">
+			<div class="card-body">
+				<div class="row justify-content-between">
+					<% if article.user.profile_image? %>
+						<%= image_tag article.user.profile_image.url, size: "70x60", class: "image_icons" %>
+					<% else %>
+						<%= image_tag ("default.png"), size: "70x60" %>
+					<% end %>
+					<h5 class="card-name"><%= article.user.name %></h5>
+					<p class="card-text-day"><%= article.day %></p>
+					<div class="dropdown drop-hover">
+						<i class="material-icons">more_vert</i>
+						<ul class="dropdown-menu">
+							<li class="dropright drop-hover">
+								<a class="dropdown-item"><%= link_to "詳細", article %></a>
+								<% if current_user.id == article.user_id %>
+									<a class="dropdown-item"><%= link_to "編集", edit_article_path(article) %></a>
+									<a class="dropdown-item"><%= link_to "削除", article_path(article), method: :delete, data: { confirm: "削除しますか？" } %></a>
+								<% end %>
+							</li>
+						</ul>
+					</div>
+				</div>
+				<div class="row justify-content-start">
+					<p>エクササイズ：<%= article.exercise.name %></p>
+					<p><%= article.minutes %>分</p>
+				</div>
+				<div class="row justify-content-start">
+					<p><%= article.body %></p>
+				</div>
+				<div class="row justify-content-end">
+					<p id="article-<%= article.id %>">
+					<% if article.liked_by?(current_user) %>
+						<%= render "like", post: article %>
+					<% else %>
+						<%= render "dislike", post: article %>
+					<% end %>
+					</p>
+				</div>
+			</div>
+		</div>
+	</div>
 </div>

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,35 +1,43 @@
 <div class="container">
   <div class="row align-items-center">
     <div class="col-12">
-      <div class="card text-center" style="height: 24rem;">
+      <div class="card" style="height: 24rem;">
         <div class="card-body">
           <%= form_with model: @article, local: true do |form| %>
-          <div class="form-group row">
-            <label class="col-sm-4 col-form-label"><%= form.label :day %></label>
-            <div class="col-sm-8">
-              <%= form.date_field :day, class: 'form-control', required: true %>
-            </div>
+        <div class="form-group row">
+          <div class="col">
+            <%= form.label :day %>
           </div>
-          <div class="form-group row">
-            <label class="col-sm-4 col-form-label"><%= form.label :exercise_id %></label>
-            <div class="col-sm-4">
-              <%= form.collection_select :exercise_id, Exercise.all, :id, :name, {prompt: ""}, class: 'form-control' %>
-            </div>
-            <div class="col-sm-3">
-              <%= form.number_field :minutes, min: "0", class: 'form-control', required: true %>
-            </div>
-            <label class="col-sm-1 col-form-label"><%= form.label :minutes %></label>
+          <div class="col">
+            <%= form.date_field :day, class: 'form-control', required: true %>
           </div>
-          <div class="form-group row">
-            <label class="col-sm-4 col-form-label"><%= form.label :body %></label>
-            <div class="col-sm-8">
-              <%= form.text_area :body, class: 'form-control', required: true %>
-            </div>
+        </div>
+        <div class="form-group row">
+          <div class="col-xs-5">
+            <%= form.label :exercise_id %>
           </div>
-          <div class="form-group row justify-content-center">
-            <%= form.submit button_value, class: 'btn btn-outline-dark btn-lg rounded-pill' %>
-            <%= link_to "もどる", user_path(id: current_user.id), class: 'btn btn-outline-dark btn-lg rounded-pill' %>
+          <div class="col">
+            <%= form.collection_select :exercise_id, Exercise.all, :id, :name, {prompt: ""}, class: 'form-control' %>  
           </div>
+          <div class="col">
+            <%= form.number_field :minutes, min: "0", class: 'form-control', required: true %>
+          </div>
+          <div class="col-xs-3">
+            <%= form.label :minutes %>
+          </div>
+        </div>
+        <div class="form-group row">
+          <div class="col">
+            <%= form.label :body %>
+          </div>
+          <div class="col-md-8">
+            <%= form.text_area :body, class: 'form-control', required: true %>
+          </div>
+        </div>
+        <div class="form-group row justify-content-center">
+          <%= form.submit button_value, class: 'btn btn-outline-dark btn-lg rounded-pill' %>
+          <%= link_to "もどる", user_path(id: current_user.id), class: 'btn btn-outline-dark btn-lg rounded-pill' %>
+        </div>
           <% end %>
         </div>
       </div>

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,19 +1,38 @@
-<%= form_with model: @article, local: true do |form| %>
-  <div>
-    <%= form.label :day %>
-    <%= form.date_field :day, required: true %>
+<div class="container">
+  <div class="row align-items-center">
+    <div class="col-12">
+      <div class="card text-center" style="height: 24rem;">
+        <div class="card-body">
+          <%= form_with model: @article, local: true do |form| %>
+          <div class="form-group row">
+            <label class="col-sm-4 col-form-label"><%= form.label :day %></label>
+            <div class="col-sm-8">
+              <%= form.date_field :day, class: 'form-control', required: true %>
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-4 col-form-label"><%= form.label :exercise_id %></label>
+            <div class="col-sm-4">
+              <%= form.collection_select :exercise_id, Exercise.all, :id, :name, {prompt: ""}, class: 'form-control' %>
+            </div>
+            <div class="col-sm-3">
+              <%= form.number_field :minutes, min: "0", class: 'form-control', required: true %>
+            </div>
+            <label class="col-sm-1 col-form-label"><%= form.label :minutes %></label>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-4 col-form-label"><%= form.label :body %></label>
+            <div class="col-sm-8">
+              <%= form.text_area :body, class: 'form-control', required: true %>
+            </div>
+          </div>
+          <div class="form-group row justify-content-center">
+            <%= form.submit button_value, class: 'btn btn-outline-dark btn-lg rounded-pill' %>
+            <%= link_to "もどる", user_path(id: current_user.id), class: 'btn btn-outline-dark btn-lg rounded-pill' %>
+          </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
   </div>
-  <div>
-    <%= form.label :exercise_id %>
-    <%= form.collection_select :exercise_id, Exercise.all, :id, :name %>
-    <%= form.number_field :minutes, min: "0" %>
-    <%= form.label :minutes, required: true %>
-  </div>
-  <div>
-    <%= form.label :body %>
-    <%= form.text_area :body, required: true %>
-  </div>
-  <div>
-    <%= form.submit button_value %>
-  </div>
-<% end %>
+</div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,3 +1,5 @@
-<h1>投稿一覧</h1>
+<div class="contents-title text-center">
+	<h1>みんなのTumieku</h1>
+</div>
 <%= render @articles %>
 <%= paginate @articles %>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,2 +1,4 @@
-<h1>今日のTumiekuをつぶやこう！</h1>
+<div class="contents-title text-center">
+  <h4>今日のTumiekuをつぶやこう！</h4>
+</div>
 <%= render "form", button_value: "投稿" %>


### PR DESCRIPTION
colse #94 
# 実装内容
- 記事投稿画面のスタイル調整
- 各カードのスタイル微調整
-  投稿一覧画面にカード挿入
- カード内にアイコン、日付、エクササイズと感想を挿入
- ページネーションの位置を調整
-  投稿画面のスマホサイズでスタイルが崩れる所を修正
- コントロラーの記述を修正